### PR TITLE
[Maintenance] Symfony 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^7.3||^8.0",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "symfony/validator": "^4.4||^5.3"
+        "symfony/validator": "^4.4||^5.3||^6.0"
     },
     "require-dev": {
         "assurance-maladie/qualytou": "^2.0",

--- a/src/Constraints/MigValidator.php
+++ b/src/Constraints/MigValidator.php
@@ -10,6 +10,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class MigValidator extends ConstraintValidator
 {
+    /**
+     * @param mixed $value
+     */
     public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof Mig) {

--- a/src/Constraints/NirValidator.php
+++ b/src/Constraints/NirValidator.php
@@ -11,6 +11,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class NirValidator extends ConstraintValidator
 {
+    /**
+     * @param mixed $value
+     */
     public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof Nir) {

--- a/src/Constraints/NnpValidator.php
+++ b/src/Constraints/NnpValidator.php
@@ -10,6 +10,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class NnpValidator extends ConstraintValidator
 {
+    /**
+     * @param mixed $value
+     */
     public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof Nnp) {


### PR DESCRIPTION
## Description
This PR add support for Symfony 6.

PHPDoc was also added on all validators as Symfony 6 added type hint on the `$value` parameter.

When running Grumphp with PHP 8.1, cs-fixer warn about all validator specs, `Constraints\Nir` and `InterfaceNotImplementedException`. It wasn't part of the changes so I left it as is. What's more, fixing them add a warning to phpmd.

Thanks for your work