### PR TITLE
Change PHP CS Fixer config to accept global namespace import

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -46,6 +46,7 @@ $config->setRiskyAllowed(true)
             'single_quote' => ['strings_containing_single_quote_chars' => true],
             'visibility_required' => ['elements' => ['property', 'method', 'const']],
             'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+            'global_namespace_import' => true,
 
             // Additional code style rules whitelisting:
             'align_multiline_comment' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -17,7 +17,7 @@ $config->setRiskyAllowed(true)
             // @Symfony code styles rules blacklisting:
             'method_chaining_indentation' => true,
             'no_singleline_whitespace_before_semicolons' => true,
-            'no_trailing_comma_in_list_call' => false,
+            'no_trailing_comma_in_singleline' => false,
             'php_unit_fqcn_annotation' => false,
             'phpdoc_align' => false,
             'phpdoc_annotation_without_dot' => false,
@@ -47,6 +47,7 @@ $config->setRiskyAllowed(true)
             'visibility_required' => ['elements' => ['property', 'method', 'const']],
             'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
             'global_namespace_import' => true,
+            'no_superfluous_phpdoc_tags' => false,
 
             // Additional code style rules whitelisting:
             'align_multiline_comment' => true,

--- a/src/Constraints/Mig.php
+++ b/src/Constraints/Mig.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Cnamts\Nir\Constraints;
 
+use Attribute;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Mig extends Constraint
 {
     public const LENGTH_ERROR = '1583444a-059d-452a-9cd2-9611cdf4fc09';

--- a/src/Constraints/Nir.php
+++ b/src/Constraints/Nir.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cnamts\Nir\Constraints;
 
+use Attribute;
 use Cnamts\Nir\Exception\InterfaceNotImplementedException;
 use Cnamts\Nir\Exception\NoArgumentError;
 use Cnamts\Nir\NirKey;
@@ -15,7 +16,7 @@ use Symfony\Component\Validator\Constraint;
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Nir extends Constraint
 {
     public const LENGTH_ERROR = '132da656-8944-475d-b502-3ca00c6c3528';

--- a/src/Constraints/Nnp.php
+++ b/src/Constraints/Nnp.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Cnamts\Nir\Constraints;
 
+use Attribute;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Nnp extends Constraint
 {
     public const LENGTH_ERROR = 'db0f9fac-881c-4319-9abb-7bb4bc750b83';

--- a/src/Exception/NoArgumentError.php
+++ b/src/Exception/NoArgumentError.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Cnamts\Nir\Exception;
 
-class NoArgumentError extends \TypeError
+use TypeError;
+
+class NoArgumentError extends TypeError
 {
     public function __construct(int $nbParameters)
     {

--- a/tests/Spec/Cnamts/Nir/Constraints/MigValidatorSpec.php
+++ b/tests/Spec/Cnamts/Nir/Constraints/MigValidatorSpec.php
@@ -59,7 +59,7 @@ class MigValidatorSpec extends ObjectBehavior
     public function it_expects_constraint_compatible_type()
     {
         $this->shouldThrow(UnexpectedTypeException::class)
-            ->during('validate', ['', (new class() extends Constraint {})])
+            ->during('validate', ['', new class() extends Constraint {}])
         ;
     }
 }

--- a/tests/Spec/Cnamts/Nir/Constraints/NirValidatorSpec.php
+++ b/tests/Spec/Cnamts/Nir/Constraints/NirValidatorSpec.php
@@ -74,7 +74,7 @@ class NirValidatorSpec extends ObjectBehavior
     public function it_expects_constraint_compatible_type()
     {
         $this->shouldThrow(UnexpectedTypeException::class)
-            ->during('validate', ['', (new class() extends Constraint {})])
+            ->during('validate', ['', new class() extends Constraint {}])
         ;
     }
 }

--- a/tests/Spec/Cnamts/Nir/Constraints/NnpValidatorSpec.php
+++ b/tests/Spec/Cnamts/Nir/Constraints/NnpValidatorSpec.php
@@ -58,7 +58,7 @@ class NnpValidatorSpec extends ObjectBehavior
     public function it_expects_constraint_compatible_type()
     {
         $this->shouldThrow(UnexpectedTypeException::class)
-            ->during('validate', ['', (new class() extends Constraint {})])
+            ->during('validate', ['', new class() extends Constraint {}])
         ;
     }
 }


### PR DESCRIPTION
It looks like PHP CS Fixer and PHPMD are not agreeing on how the global namespace classes should be used / imported.

I changed PHP CS Fixer rule to please PHPMD.