### PR TITLE
Fix Symfony 6.1 deprecation notice on $errorNames array

### DIFF
--- a/src/Constraints/Mig.php
+++ b/src/Constraints/Mig.php
@@ -24,8 +24,14 @@ class Mig extends Constraint
     public $migMessage = 'Cette valeur n\'est pas au format MIG.';
 
     /** @var array<string, string> */
-    protected static $errorNames = [
+    protected const ERROR_NAMES = [
         self::LENGTH_ERROR => 'LENGTH_ERROR',
         self::MIG_INVALID => 'MIG_INVALID',
     ];
+
+    /**
+     * @var array<string, string>
+     * @deprecated since Symfony 6.1, use const ERROR_NAMES instead
+     */
+    protected static $errorNames = self::ERROR_NAMES;
 }

--- a/src/Constraints/Nir.php
+++ b/src/Constraints/Nir.php
@@ -33,11 +33,17 @@ class Nir extends Constraint
     public $nirKeyMessage = 'La clé ne correspond pas au NIR fourni.';
 
     /** @var array<string, string> */
-    protected static $errorNames = [
+    protected const ERROR_NAMES = [
         self::LENGTH_ERROR => 'LENGTH_ERROR',
         self::NIR_INVALID => 'NIR_INVALID',
         self::NIR_KEY_INVALID => 'NIR_KEY_INVALID',
     ];
+
+    /**
+     * @var array<string, string>
+     * @deprecated since Symfony 6.1, use const ERROR_NAMES instead
+     */
+    protected static $errorNames = self::ERROR_NAMES;
 
     /** @var NirKeyInterface */
     public $nirKey;

--- a/src/Constraints/Nnp.php
+++ b/src/Constraints/Nnp.php
@@ -24,8 +24,14 @@ class Nnp extends Constraint
     public $nnpMessage = 'Cette valeur n\'est pas au format NNP.';
 
     /** @var array<string, string> */
-    protected static $errorNames = [
+    protected const ERROR_NAMES = [
         self::LENGTH_ERROR => 'LENGTH_ERROR',
         self::NNP_INVALID => 'NNP_INVALID',
     ];
+
+    /**
+     * @var array<string, string>
+     * @deprecated since Symfony 6.1, use const ERROR_NAMES instead
+     */
+    protected static $errorNames = self::ERROR_NAMES;
 }


### PR DESCRIPTION
Based on https://github.com/assurance-maladie-digital/nir-validation/pull/6 to have a green CI.

See https://github.com/symfony/symfony/pull/45371

BC Layer kept.