### PR TITLE
Compatibilité Symfony 7.0 et validation des NNP avant 2012

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^7.3||^8.0",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "symfony/validator": "^4.4||^5.3||^6.0"
+        "symfony/validator": "^4.4||^5.3||^6.0||^7.0"
     },
     "require-dev": {
         "assurance-maladie/qualytou": "^2.0",

--- a/src/Constraints/Nnp.php
+++ b/src/Constraints/Nnp.php
@@ -34,4 +34,17 @@ class Nnp extends Constraint
      * @deprecated since Symfony 6.1, use const ERROR_NAMES instead
      */
     protected static $errorNames = self::ERROR_NAMES;
+
+    /**
+     * Indique si les règles de format des NNP avant 2012 doivent être appliquées.
+     *
+     * Si true, le système accepte les NNP avec un 0, conformément aux
+     * anciennes règles dont la trace a été perdue mais qui concernent encore
+     * certains assurés.
+     * Si false, seules les règles post-2012, qui ne permettent pas les NNP
+     * avec un 0, seront appliquées.
+     *
+     * @var bool
+     */
+    public $useBefore2012 = false;
 }

--- a/src/Constraints/NnpValidator.php
+++ b/src/Constraints/NnpValidator.php
@@ -35,7 +35,7 @@ class NnpValidator extends ConstraintValidator
             return;
         }
 
-        if (!$this->check($nnp)) {
+        if (!$this->check($nnp, $constraint)) {
             $this->context->buildViolation($constraint->nnpMessage)
                 ->setInvalidValue($value)
                 ->setCode(Nnp::NNP_INVALID)
@@ -50,12 +50,15 @@ class NnpValidator extends ConstraintValidator
      * le 3ème composant est un groupe de trois chiffres correspondant au numéro de caisse ;
      * le 4ème composant correspond au numéro d'ordre par caisse ;
      */
-    private function check(string $nnp): bool
+    private function check(string $nnp, Nnp $constraint): bool
     {
+        // Si useBefore2012 est true, on autorise également la valeur '0' dans la partie 'verification'
+        $verificationPattern = $constraint->useBefore2012 ? '[012]' : '[12]';
+
         return (bool) preg_match(
             '/\A' .
             '(?<sexe>[78])' .
-            '(?<verification>[12])' .
+            '(?<verification>' . $verificationPattern . ')' .
             '(?<numero_caisse>\d{3})' .
             '(?<numero_ordre>\d{8})' .
             '\z/i',

--- a/tests/Spec/Cnamts/Nir/Constraints/NnpValidatorSpec.php
+++ b/tests/Spec/Cnamts/Nir/Constraints/NnpValidatorSpec.php
@@ -58,7 +58,31 @@ class NnpValidatorSpec extends ObjectBehavior
     public function it_expects_constraint_compatible_type()
     {
         $this->shouldThrow(UnexpectedTypeException::class)
-            ->during('validate', ['', new class() extends Constraint {}])
+            ->during('validate', ['', new class extends Constraint {}])
         ;
+    }
+
+    public function it_accepts_nnp_with_zero_when_before_2012_is_true()
+    {
+        $nnp = new Nnp();
+        $nnp->useBefore2012 = true; // Activer la règle avant 2012
+        $this->validate('7012312345678', $nnp); // NNP valide avec '0' dans le champ verification
+    }
+
+    public function it_does_not_accept_nnp_with_zero_when_before_2012_is_false(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder
+    ) {
+        $nnp = new Nnp();
+        $nnp->useBefore2012 = false; // Règles post-2012 (comportement par défaut)
+        $value = '7012312345678'; // NNP avec '0' ne doit pas être accepté
+
+        $context->buildViolation($nnp->nnpMessage)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setInvalidValue($value)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setCode(Nnp::NNP_INVALID)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->initialize($context);
+        $this->validate($value, $nnp);
     }
 }


### PR DESCRIPTION
Cette mise à jour apporte deux changements importants sans modification de la version minimale de PHP (qui reste à 7.3) :

#### **Changements :**

1. Compatibilité Symfony 7.0
2. Ajout de la validation des NNP avant 2012